### PR TITLE
Fix DelayRandom range handling

### DIFF
--- a/Calc/ViewModels/MainWindowViewModel.cs
+++ b/Calc/ViewModels/MainWindowViewModel.cs
@@ -439,11 +439,12 @@ namespace Calc.ViewModels
 		/// </summary>
 		/// <param name="from">最低遅延秒</param>
 		/// <param name="to">最高遅延秒</param>
-		private void DelayRandom(uint from, uint to)
-		{
-			Random rand = new Random((int)DateTime.Now.Ticks);
-			System.Threading.Thread.Sleep(rand.Next(0, 700));
-		}
+                private void DelayRandom(uint from, uint to)
+                {
+                        Random rand = new Random((int)DateTime.Now.Ticks);
+                        // Use the supplied range for the delay instead of a fixed one
+                        System.Threading.Thread.Sleep(rand.Next((int)from, (int)to));
+                }
 
 		/// <summary>
 		/// 計算する

--- a/Calc/ViewModels/MainWindowViewModel.cs
+++ b/Calc/ViewModels/MainWindowViewModel.cs
@@ -442,7 +442,6 @@ namespace Calc.ViewModels
                 private void DelayRandom(uint from, uint to)
                 {
                         Random rand = new Random((int)DateTime.Now.Ticks);
-                        // Use the supplied range for the delay instead of a fixed one
                         System.Threading.Thread.Sleep(rand.Next((int)from, (int)to));
                 }
 


### PR DESCRIPTION
## Summary
- use DelayRandom arguments instead of a hard-coded range

## Testing
- `dotnet --version` *(fails: command not found)*
- `msbuild /version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687331f82e90832e89f509aeb9da6f2d